### PR TITLE
Fix device orientation mirror

### DIFF
--- a/ios/RCTWebRTC/RTCVideoViewManager.m
+++ b/ios/RCTWebRTC/RTCVideoViewManager.m
@@ -189,10 +189,17 @@ typedef NS_ENUM(NSInteger, RTCVideoViewObjectFit) {
     subview.frame = newValue;
   }
 
-  subview.transform
-    = self.mirror
-        ? CGAffineTransformMakeScale(-1.0, 1.0)
-        : CGAffineTransformIdentity;
+  if(self.mirror) {
+    if (CGRectGetWidth(subview.bounds) > CGRectGetHeight(subview.bounds)) {
+        // Landscape
+        subview.transform = CGAffineTransformMakeScale(1.0, -1.0);
+    } else {
+        // Portrait
+        subview.transform = CGAffineTransformMakeScale(-1.0, 1.0);
+    }
+  } else {
+    subview.transform = CGAffineTransformIdentity;
+  }
 }
 
 /**


### PR DESCRIPTION
If the Video gets switched to landscape we can't transform on the X axis anymore because that means flipping it upside down. I'm not sure if this the correct approach because it seems like the underlying view should know that the orientation has changed and the appropriately change the axis of the video, but no clue how to start with that.

